### PR TITLE
exit if no refs in the repo

### DIFF
--- a/ImgBot.Function/CompressImages.cs
+++ b/ImgBot.Function/CompressImages.cs
@@ -36,9 +36,12 @@ namespace ImgBot.Function
             var repo = new LibGit2Sharp.Repository(parameters.LocalPath);
             var remote = repo.Network.Remotes["origin"];
 
-            // check if we have the branch already
+            // check if we have the branch already or this is empty repo
             try
             {
+                if (repo.Network.ListReferences(remote, credentialsProvider).Any() == false)
+                    return;
+
                 if (repo.Network.ListReferences(remote, credentialsProvider).Any(x => x.CanonicalName == $"refs/heads/{BranchName}"))
                     return;
             }


### PR DESCRIPTION
when ImgBot is installed into a repo that has no commits yet then it throws exception trying to checkout a branch. Typical example is the installation setting to install into all future repos.