### PR TITLE
snap to new access token pattern (fixes #146)

### DIFF
--- a/Common/KnownGitHubs.cs
+++ b/Common/KnownGitHubs.cs
@@ -19,5 +19,10 @@
         public const string Username = "x-access-token";
 
         public const string BranchName = "imgbot";
+
+        /// <remarks>
+        /// {0} = installation_id
+        /// </remarks>
+        public const string AccessTokensUrlFormat = "https://api.github.com/app/installations/{0}/access_tokens";
     }
 }

--- a/Common/Messages/CompressImagesMessage.cs
+++ b/Common/Messages/CompressImagesMessage.cs
@@ -2,8 +2,6 @@
 {
     public class CompressImagesMessage
     {
-        public string AccessTokensUrl { get; set; }
-
         public string CloneUrl { get; set; }
 
         public string RepoName { get; set; }

--- a/Common/Messages/RouterMessage.cs
+++ b/Common/Messages/RouterMessage.cs
@@ -6,8 +6,6 @@
 
         public string RepoName { get; set; }
 
-        public string AccessTokensUrl { get; set; }
-
         public string CloneUrl { get; set; }
 
         public string Owner { get; set; }

--- a/Common/TableModels/Installation.cs
+++ b/Common/TableModels/Installation.cs
@@ -21,8 +21,6 @@ namespace Common.TableModels
 
         public string RepoName { get; set; }
 
-        public string AccessTokensUrl { get; set; }
-
         public string CloneUrl { get; set; }
 
         public string Owner { get; set; }

--- a/CompressImagesFunction/CompressImagesFunction.cs
+++ b/CompressImagesFunction/CompressImagesFunction.cs
@@ -20,7 +20,7 @@ namespace CompressImagesFunction
         {
             var installationTokenParameters = new InstallationTokenParameters
             {
-                AccessTokensUrl = compressImagesMessage.AccessTokensUrl,
+                AccessTokensUrl = string.Format(KnownGitHubs.AccessTokensUrlFormat, compressImagesMessage.InstallationId),
                 AppId = KnownGitHubs.AppId,
             };
 

--- a/OpenPrFunction/OpenPr.cs
+++ b/OpenPrFunction/OpenPr.cs
@@ -27,7 +27,7 @@ namespace OpenPrFunction
 
             var installationTokenParameters = new InstallationTokenParameters
             {
-                AccessTokensUrl = installation.AccessTokensUrl,
+                AccessTokensUrl = string.Format(KnownGitHubs.AccessTokensUrlFormat, installation.InstallationId),
                 AppId = KnownGitHubs.AppId,
             };
 

--- a/PrPoisonHandler/PrPoisonFunction.cs
+++ b/PrPoisonHandler/PrPoisonFunction.cs
@@ -63,7 +63,7 @@ namespace PrPoisonHandler
 
                     var installationTokenParameters = new InstallationTokenParameters
                     {
-                        AccessTokensUrl = installation.AccessTokensUrl,
+                        AccessTokensUrl = string.Format(KnownGitHubs.AccessTokensUrlFormat, topMessage.InstallationId),
                         AppId = KnownGitHubs.AppId,
                     };
 

--- a/RouterFunction/RouterFunction.cs
+++ b/RouterFunction/RouterFunction.cs
@@ -20,7 +20,6 @@ namespace RouterFunction
             {
                 installations.Add(new Installation(routerMessage.InstallationId, routerMessage.RepoName)
                 {
-                    AccessTokensUrl = routerMessage.AccessTokensUrl,
                     CloneUrl = routerMessage.CloneUrl,
                     Owner = routerMessage.Owner,
                 });
@@ -35,7 +34,6 @@ namespace RouterFunction
 
             compressImagesMessages.Add(new CompressImagesMessage
             {
-                AccessTokensUrl = routerMessage.AccessTokensUrl,
                 CloneUrl = routerMessage.CloneUrl,
                 InstallationId = routerMessage.InstallationId,
                 Owner = routerMessage.Owner,

--- a/Web/Controllers/HookController.cs
+++ b/Web/Controllers/HookController.cs
@@ -80,7 +80,6 @@ namespace Web.Controllers
             {
                 InstallationId = hook.installation.id,
                 Owner = hook.repository.owner.login,
-                AccessTokensUrl = $"https://api.github.com/installations/{hook.installation.id}/access_tokens", // access_tokens url not available from this hook :(
                 RepoName = hook.repository.name,
                 CloneUrl = $"https://github.com/{hook.repository.full_name}",
             });
@@ -97,7 +96,6 @@ namespace Web.Controllers
                     {
                         InstallationId = hook.installation.id,
                         Owner = hook.installation.account.login,
-                        AccessTokensUrl = hook.installation.access_tokens_url,
                         RepoName = repo.name,
                         CloneUrl = $"https://github.com/{repo.full_name}",
                     })));
@@ -109,7 +107,6 @@ namespace Web.Controllers
                     {
                         InstallationId = hook.installation.id,
                         Owner = hook.installation.account.login,
-                        AccessTokensUrl = hook.installation.access_tokens_url,
                         RepoName = repo.name,
                         CloneUrl = $"https://github.com/{repo.full_name}",
                     })));


### PR DESCRIPTION
 - stop passing around and storing access tokens just format on the fly
 - see https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/