### PR TITLE
Increase CompressImages function timeout

### DIFF
--- a/CompressImagesFunction/host.json
+++ b/CompressImagesFunction/host.json
@@ -1,2 +1,4 @@
 {
+  "version": "2.0",
+  "functionTimeout": "00:10:00"
 }


### PR DESCRIPTION
Increases function timeout to 10 minutes as requested.

Fixes issue #112 