### PR TITLE
Assorted changes to skip compression of archived repos as per issue #93:

### DIFF
--- a/Common/GitHubClientParameters.cs
+++ b/Common/GitHubClientParameters.cs
@@ -1,6 +1,6 @@
-﻿namespace OpenPrFunction
+﻿namespace Common
 {
-    public class PullRequestParameters
+    public class GitHubClientParameters
     {
         public string RepoOwner { get; set; }
 

--- a/CompressImagesFunction/CompressImagesFunction.csproj
+++ b/CompressImagesFunction/CompressImagesFunction.csproj
@@ -79,6 +79,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.8.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
+    <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CompressImagesFunction/IRepoChecks.cs
+++ b/CompressImagesFunction/IRepoChecks.cs
@@ -1,5 +1,5 @@
-﻿using Common;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Common;
 
 namespace CompressImagesFunction
 {

--- a/CompressImagesFunction/IRepoChecks.cs
+++ b/CompressImagesFunction/IRepoChecks.cs
@@ -1,0 +1,10 @@
+﻿using Common;
+using System.Threading.Tasks;
+
+namespace CompressImagesFunction
+{
+    public interface IRepoChecks
+    {
+        Task<bool> IsArchived(GitHubClientParameters parameters);
+    }
+}

--- a/CompressImagesFunction/RepoChecks.cs
+++ b/CompressImagesFunction/RepoChecks.cs
@@ -1,0 +1,24 @@
+﻿using Common;
+using Octokit;
+using Octokit.Internal;
+using System.Threading.Tasks;
+
+namespace CompressImagesFunction
+{
+    public class RepoChecks : IRepoChecks
+    {
+        public async Task<bool> IsArchived(GitHubClientParameters parameters)
+        {
+            var inMemoryCredentialStore = new InMemoryCredentialStore(
+                new Credentials(KnownGitHubs.Username, parameters.Password));
+
+            var githubClient = new GitHubClient(
+                new ProductHeaderValue("ImgBot"), inMemoryCredentialStore);
+
+            var repo = await githubClient.Repository.Get(
+                parameters.RepoOwner, parameters.RepoName);
+
+            return repo.Archived;
+        }
+    }
+}

--- a/CompressImagesFunction/RepoChecks.cs
+++ b/CompressImagesFunction/RepoChecks.cs
@@ -1,7 +1,7 @@
-﻿using Common;
+﻿using System.Threading.Tasks;
+using Common;
 using Octokit;
 using Octokit.Internal;
-using System.Threading.Tasks;
 
 namespace CompressImagesFunction
 {

--- a/OpenPrFunction/IPullRequest.cs
+++ b/OpenPrFunction/IPullRequest.cs
@@ -1,5 +1,5 @@
-﻿using Common;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Common;
 
 namespace OpenPrFunction
 {

--- a/OpenPrFunction/IPullRequest.cs
+++ b/OpenPrFunction/IPullRequest.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using Common;
+using System.Threading.Tasks;
 
 namespace OpenPrFunction
 {
     public interface IPullRequest
     {
-        Task<long> OpenAsync(PullRequestParameters parameters);
+        Task<long> OpenAsync(GitHubClientParameters parameters);
     }
 }

--- a/OpenPrFunction/OpenPr.cs
+++ b/OpenPrFunction/OpenPr.cs
@@ -48,7 +48,7 @@ namespace OpenPrFunction
                 File.OpenText(Path.Combine(context.FunctionDirectory, $"../{KnownGitHubs.AppPrivateKey}")));
 
             logger.LogInformation("OpenPrFunction: Opening pull request for {Owner}/{RepoName}", installation.Owner, installation.RepoName);
-            var id = await pullRequest.OpenAsync(new PullRequestParameters
+            var id = await pullRequest.OpenAsync(new GitHubClientParameters
             {
                 Password = installationToken.Token,
                 RepoName = installation.RepoName,

--- a/OpenPrFunction/PullRequest.cs
+++ b/OpenPrFunction/PullRequest.cs
@@ -7,7 +7,7 @@ namespace OpenPrFunction
 {
     public class PullRequest : IPullRequest
     {
-        public async Task<long> OpenAsync(PullRequestParameters parameters)
+        public async Task<long> OpenAsync(GitHubClientParameters parameters)
         {
             var inMemoryCredentialStore = new InMemoryCredentialStore(new Credentials(KnownGitHubs.Username, parameters.Password));
 

--- a/Test/OpenPrTests.cs
+++ b/Test/OpenPrTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Common;
 using Common.Messages;
 using Common.TableModels;
 using Install;
@@ -121,7 +122,7 @@ namespace Test
                  }));
 
             var pullRequest = Substitute.For<IPullRequest>();
-            pullRequest.OpenAsync(Arg.Any<PullRequestParameters>()).Returns(x => Task.FromResult(prId));
+            pullRequest.OpenAsync(Arg.Any<GitHubClientParameters>()).Returns(x => Task.FromResult(prId));
 
             return OpenPr.RunAsync(openPrMessage, installation, installationTokenProvider, pullRequest, logger, context);
         }

--- a/Test/RepoCheckTests.cs
+++ b/Test/RepoCheckTests.cs
@@ -1,0 +1,80 @@
+﻿using Install;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CompressImagesFunction;
+using Common;
+using Common.Messages;
+using Common.TableModels;
+using Microsoft.Azure.WebJobs;
+
+namespace Test
+{
+    [TestClass]
+    public class RepoCheckTests
+    {
+        [TestMethod]
+        public async Task GivenArchivedRepo_ShouldSkip()
+        {
+            await ExecuteRunAsync(12345, "dabutvin", "test", 150, out var logger);
+
+            logger.AssertCallCount(2);
+            logger.SecondCall().AssertLogLevel(LogLevel.Information);
+            logger.SecondCall().AssertLogMessage("CompressImagesFunction: skipping archived repo {Owner}/{RepoName}");
+            logger.SecondCall().AssertLogValues(
+                KeyValuePair.Create("Owner", "dabutvin"),
+                KeyValuePair.Create("RepoName", "test"));
+        }
+
+        private Task ExecuteRunAsync(int installationId, string owner, string repoName, long prId, out ILogger logger)
+        {
+            var cloneUrl = $"https://github.com/{owner}/{repoName}";
+
+            var compressImagesMessage = new CompressImagesMessage
+            {
+                CloneUrl = cloneUrl,
+                Owner = owner,
+                InstallationId = installationId,
+                RepoName = repoName
+            };
+
+            return ExecuteRunAsync(compressImagesMessage, prId, out logger);
+        }
+
+        private Task ExecuteRunAsync(CompressImagesMessage compressImagesMessage, long prId, out ILogger logger)
+        {
+            logger = Substitute.For<ILogger>();
+
+            var context = Substitute.For<ExecutionContext>();
+            context.FunctionDirectory = "data/functiondir";
+
+            var installationTokenProvider = Substitute.For<IInstallationTokenProvider>();
+            installationTokenProvider
+                 .GenerateAsync(Arg.Any<InstallationTokenParameters>(), Arg.Any<StreamReader>())
+                 .Returns(Task.FromResult(new InstallationToken
+                 {
+                     Token = "token",
+                     ExpiresAt = "12345"
+                 }));
+
+            var openPrMessages = Substitute.For<ICollector<OpenPrMessage>>();
+
+            var repoChecks = Substitute.For<IRepoChecks>();
+            repoChecks.IsArchived(Arg.Any<GitHubClientParameters>())
+                .Returns(x => Task.FromResult(true));
+
+            return CompressImagesFunction.CompressImagesFunction.RunAsync(
+                installationTokenProvider,
+                compressImagesMessage,
+                openPrMessages,
+                repoChecks,
+                logger,
+                context);
+        }
+    }
+}

--- a/Test/RepoCheckTests.cs
+++ b/Test/RepoCheckTests.cs
@@ -1,17 +1,14 @@
-﻿using Install;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Common;
+using Common.Messages;
+using CompressImagesFunction;
+using Install;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using CompressImagesFunction;
-using Common;
-using Common.Messages;
-using Common.TableModels;
-using Microsoft.Azure.WebJobs;
 
 namespace Test
 {


### PR DESCRIPTION
- Added a new RepoChecks class and interface for performing checks on repositories, including a check for archival
- Modified CompressImagesFunction to receive a RepoChecks instance, check IsArchived and skip compression if true
- Renamed PullRequestParameters to GitHubClientParameters and moved into Common project, updated existing references
- Added new test class for RepoCheckTests (copied from OpenPrTests - common code could probably use refactoring)