### PR TITLE
Change the label a stale issue gets

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: goneStale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - hacktoberfest
 # Label to use when marking an issue as stale
 staleLabel: goneStale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
I want the label "wontfix" only on issues where you decide so, not on any one that gets just stale.
"wontfix" gives the wrong impression, so I chose "goneStale"

BTW: a label "pinned" prevents stalebot from acting on an issue.

Signed-off-by: G. Reiter <guntbert@gmx.at>