### PR TITLE
Configuring ImageOptimizer IgnoreUnsupportedFormats setting

### DIFF
--- a/CompressImagesFunction/CompressImages.cs
+++ b/CompressImagesFunction/CompressImages.cs
@@ -133,7 +133,8 @@ namespace CompressImagesFunction
             var optimizedImages = new List<CompressionResult>();
             ImageOptimizer imageOptimizer = new ImageOptimizer
             {
-                OptimalCompression = true
+                OptimalCompression = true,
+                IgnoreUnsupportedFormats = true,
             };
 
             Parallel.ForEach(imagePaths, image =>

--- a/CompressImagesFunction/CompressImagesFunction.csproj
+++ b/CompressImagesFunction/CompressImagesFunction.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.23" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.8.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.9.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>


### PR DESCRIPTION
* Upgraded Magick.NET to 7.9.0
* Added IgnoreUnsupportedFormats=true configuration flag to ImageOptimizer

Fixes #204