### PR TITLE
Omit reduction percentage for small values

### DIFF
--- a/OpenPrFunction/PullRequestBody.cs
+++ b/OpenPrFunction/PullRequestBody.cs
@@ -57,7 +57,7 @@ namespace OpenPrFunction
                 sb.AppendLine("## Beep boop. Your images are optimized!");
                 sb.AppendLine();
 
-                if (Math.Round(imageStats[0].Percent) == 0)
+                if (Math.Round(imageStats[0].Percent) < 5)
                 {
                     sb.AppendLine("Your image file size has been reduced!");
                 }

--- a/Test/PullRequestBodyTests.cs
+++ b/Test/PullRequestBodyTests.cs
@@ -78,6 +78,32 @@ namespace Test
         }
 
         [TestMethod]
+        public void GivenReductionBelow5PercentCommitMessage_ShouldOmitPercentage()
+        {
+            var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +
+                         Environment.NewLine +
+                         "/featured-marketplace.png -- 163.11kb -> 155.11kb (4.40%)" + Environment.NewLine;
+
+            var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
+                          Environment.NewLine +
+                          "Your image file size has been reduced!" + Environment.NewLine +
+                          Environment.NewLine +
+                          "<details>" + Environment.NewLine +
+                          "<summary>" + Environment.NewLine +
+                          "Details" + Environment.NewLine +
+                          "</summary>" + Environment.NewLine +
+                          Environment.NewLine +
+                          "| File | Before | After | Percent reduction |" + Environment.NewLine +
+                          "|:--|:--|:--|:--|" + Environment.NewLine +
+                          "| /featured-marketplace.png | 163.11kb | 155.11kb | 4.40% |" + Environment.NewLine +
+                          "</details>" + expectedFooter;
+
+            var result = PullRequestBody.Generate(commitMessage);
+
+            Assert.AreEqual(expectedMarkdown, result);
+        }
+
+        [TestMethod]
         public void GivenSingleImageCommitMessage_ShouldFormatMarkdownTable()
         {
             var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +


### PR DESCRIPTION
As suggested in #125 I omit the percentage not only when the reduction is *almost* 0 but already when the reduction is below 5% (rounded to the next integer, so `4,60%` will still be shown.

Fixes #125 