### PR TITLE
Notice when .imgbotconfig has been added \ modified and rescan

### DIFF
--- a/Test/data/hooks/commit-defaultbranch-config.json
+++ b/Test/data/hooks/commit-defaultbranch-config.json
@@ -1,0 +1,190 @@
+﻿{
+  "ref": "refs/heads/master",
+  "before": "15a0ba36c445625749cf0411ec611aa92d4d7d0f",
+  "after": "bcd90abb2e81e456b428e522f561aa1bc4065dd7",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/dabutvin/test/compare/15a0ba36c445...bcd90abb2e81",
+  "commits": [
+    {
+      "id": "bcd90abb2e81e456b428e522f561aa1bc4065dd7",
+      "tree_id": "eb1341494d81e45534eb66fb052a710332360acb",
+      "distinct": true,
+      "message": "Add files via upload",
+      "timestamp": "2018-08-04T13:28:48-07:00",
+      "url": "https://github.com/dabutvin/test/commit/bcd90abb2e81e456b428e522f561aa1bc4065dd7",
+      "author": {
+        "name": "Dan Butvinik",
+        "email": "butvinik@outlook.com",
+        "username": "dabutvin"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "username": "web-flow"
+      },
+      "added": [
+        ".imgbotconfig"
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "bcd90abb2e81e456b428e522f561aa1bc4065dd7",
+    "tree_id": "eb1341494d81e45534eb66fb052a710332360acb",
+    "distinct": true,
+    "message": "Create .imgbotconfig",
+    "timestamp": "2018-08-04T13:28:48-07:00",
+    "url": "https://github.com/dabutvin/test/commit/bcd90abb2e81e456b428e522f561aa1bc4065dd7",
+    "author": {
+      "name": "Dan Butvinik",
+      "email": "butvinik@outlook.com",
+      "username": "dabutvin"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com",
+      "username": "web-flow"
+    },
+    "added": [
+      ".imgbotconfig"
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+
+    ]
+  },
+  "repository": {
+    "id": 130265863,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMzAyNjU4NjM=",
+    "name": "test",
+    "full_name": "dabutvin/test",
+    "owner": {
+      "name": "dabutvin",
+      "email": "butvinik@outlook.com",
+      "login": "dabutvin",
+      "id": 5168796,
+      "node_id": "MDQ6VXNlcjUxNjg3OTY=",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5168796?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/dabutvin",
+      "html_url": "https://github.com/dabutvin",
+      "followers_url": "https://api.github.com/users/dabutvin/followers",
+      "following_url": "https://api.github.com/users/dabutvin/following{/other_user}",
+      "gists_url": "https://api.github.com/users/dabutvin/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/dabutvin/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/dabutvin/subscriptions",
+      "organizations_url": "https://api.github.com/users/dabutvin/orgs",
+      "repos_url": "https://api.github.com/users/dabutvin/repos",
+      "events_url": "https://api.github.com/users/dabutvin/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/dabutvin/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/dabutvin/test",
+    "description": null,
+    "fork": false,
+    "url": "https://github.com/dabutvin/test",
+    "forks_url": "https://api.github.com/repos/dabutvin/test/forks",
+    "keys_url": "https://api.github.com/repos/dabutvin/test/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/dabutvin/test/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/dabutvin/test/teams",
+    "hooks_url": "https://api.github.com/repos/dabutvin/test/hooks",
+    "issue_events_url": "https://api.github.com/repos/dabutvin/test/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/dabutvin/test/events",
+    "assignees_url": "https://api.github.com/repos/dabutvin/test/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/dabutvin/test/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/dabutvin/test/tags",
+    "blobs_url": "https://api.github.com/repos/dabutvin/test/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/dabutvin/test/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/dabutvin/test/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/dabutvin/test/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/dabutvin/test/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/dabutvin/test/languages",
+    "stargazers_url": "https://api.github.com/repos/dabutvin/test/stargazers",
+    "contributors_url": "https://api.github.com/repos/dabutvin/test/contributors",
+    "subscribers_url": "https://api.github.com/repos/dabutvin/test/subscribers",
+    "subscription_url": "https://api.github.com/repos/dabutvin/test/subscription",
+    "commits_url": "https://api.github.com/repos/dabutvin/test/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/dabutvin/test/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/dabutvin/test/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/dabutvin/test/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/dabutvin/test/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/dabutvin/test/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/dabutvin/test/merges",
+    "archive_url": "https://api.github.com/repos/dabutvin/test/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/dabutvin/test/downloads",
+    "issues_url": "https://api.github.com/repos/dabutvin/test/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/dabutvin/test/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/dabutvin/test/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/dabutvin/test/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/dabutvin/test/labels{/name}",
+    "releases_url": "https://api.github.com/repos/dabutvin/test/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/dabutvin/test/deployments",
+    "created_at": 1524167656,
+    "updated_at": "2018-08-04T20:28:38Z",
+    "pushed_at": 1533414529,
+    "git_url": "git://github.com/dabutvin/test.git",
+    "ssh_url": "git@github.com:dabutvin/test.git",
+    "clone_url": "https://github.com/dabutvin/test.git",
+    "svn_url": "https://github.com/dabutvin/test",
+    "homepage": null,
+    "size": 5556,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_projects": false,
+    "has_downloads": true,
+    "has_wiki": false,
+    "has_pages": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "open_issues_count": 1,
+    "license": null,
+    "forks": 0,
+    "open_issues": 1,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "dabutvin",
+    "email": "butvinik@outlook.com"
+  },
+  "sender": {
+    "login": "dabutvin",
+    "id": 5168796,
+    "node_id": "MDQ6VXNlcjUxNjg3OTY=",
+    "avatar_url": "https://avatars2.githubusercontent.com/u/5168796?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/dabutvin",
+    "html_url": "https://github.com/dabutvin",
+    "followers_url": "https://api.github.com/users/dabutvin/followers",
+    "following_url": "https://api.github.com/users/dabutvin/following{/other_user}",
+    "gists_url": "https://api.github.com/users/dabutvin/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/dabutvin/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/dabutvin/subscriptions",
+    "organizations_url": "https://api.github.com/users/dabutvin/orgs",
+    "repos_url": "https://api.github.com/users/dabutvin/repos",
+    "events_url": "https://api.github.com/users/dabutvin/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/dabutvin/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "installation": {
+    "id": 23199
+  }
+}

--- a/WebHook/WebHookFunction.cs
+++ b/WebHook/WebHookFunction.cs
@@ -92,13 +92,14 @@ namespace WebHook
                 return "Commit to non default branch";
             }
 
-            var files = hook.commits.SelectMany(x => x.added)
-                .Concat(hook.commits.SelectMany(x => x.modified))
-                .Where(file => KnownImgPatterns.ImgExtensions.Any(extension => file.ToLower().EndsWith(extension, StringComparison.Ordinal)));
+            var relevantFiles = hook.commits.SelectMany(x => x.added)
+                .Concat(hook.commits.SelectMany(x => x.modified));
+            var imageFiles = relevantFiles.Where(file => KnownImgPatterns.ImgExtensions.Any(extension => file.ToLower().EndsWith(extension, StringComparison.Ordinal)));
+            var configFile = relevantFiles.Where(file => file.ToLower() == ".imgbotconfig");
 
-            if (files.Any() == false)
+            if (!imageFiles.Any() && !configFile.Any())
             {
-                return "No image files touched";
+                return "No relevant files touched";
             }
 
             await routerMessages.AddMessageAsync(new CloudQueueMessage(JsonConvert.SerializeObject(new RouterMessage


### PR DESCRIPTION
Fixes Issue #272 

The Webhook function now also looks for `.imgbotconfig` when reading commit hooks.  Note that it only looks in the root of the repo (which I think makes sense, since this config file needs to be at the repository root anyway?)

I've also had a stab at writing a test, basing it heavily on the image version.  Luckily your test repo contains a commit including .imgbotconfig, so I copied an existing hook file and edited appropriately to look like a webhook from there :-).

The tests all pass, but I couldn't work out how to run Stylecop from VS Code (so that might fail)

Thanks!