### PR TITLE
fallback to a linux machine when there is trouble cloning

### DIFF
--- a/CompressImagesFunction/CompressImagesFunction.cs
+++ b/CompressImagesFunction/CompressImagesFunction.cs
@@ -75,10 +75,11 @@ namespace CompressImagesFunction
                 RepoName = compressImagesMessage.RepoName,
                 RepoOwner = compressImagesMessage.Owner,
                 PgpPrivateKeyStream = File.OpenRead(Path.Combine(context.FunctionDirectory, $"../{KnownGitHubs.PGPPrivateKeyFilename}")),
-                PgPPassword = File.ReadAllText(Path.Combine(context.FunctionDirectory, $"../{KnownGitHubs.PGPPasswordFilename}"))
+                PgPPassword = File.ReadAllText(Path.Combine(context.FunctionDirectory, $"../{KnownGitHubs.PGPPasswordFilename}")),
+                CompressImagesMessage = compressImagesMessage,
             };
 
-            var didCompress = CompressImages.Run(compressImagesParameters, logger);
+            var didCompress = await CompressImages.RunAsync(compressImagesParameters, logger);
 
             if (didCompress)
             {

--- a/CompressImagesFunction/CompressImagesFunction.csproj
+++ b/CompressImagesFunction/CompressImagesFunction.csproj
@@ -6,8 +6,10 @@
 
   <Target Name="CopyNativeBinaries" AfterTargets="Build">
     <ItemGroup>
+      <NativeBinary Include="$(TargetDir)bin/runtimes/linux-x64/native/libgit2-4aecb64.so" />
       <NativeBinary Include="$(TargetDir)bin/runtimes/osx/native/libgit2-4aecb64.dylib" />
       <NativeBinary Include="$(TargetDir)bin/runtimes/win-x86/native/git2-4aecb64.dll" />
+      <NativeBinary Include="$(TargetDir)bin/runtimes/linux-x64/native/Magick.NET-Q16-x64.Native.dll.so" />
       <NativeBinary Include="$(TargetDir)bin/runtimes/osx-x64/native/Magick.NET-Q16-x64.Native.dll.dylib" />
       <NativeBinary Include="$(TargetDir)bin/runtimes/win-x64/native/Magick.NET-Q16-x64.Native.dll" />
     </ItemGroup>
@@ -21,6 +23,7 @@
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.10.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.1" />
     <PackageReference Include="Octokit" Version="0.32.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CompressImagesFunction/CompressimagesParameters.cs
+++ b/CompressImagesFunction/CompressimagesParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Common.Messages;
 
 namespace CompressImagesFunction
 {
@@ -17,5 +18,7 @@ namespace CompressImagesFunction
         public Stream PgpPrivateKeyStream { get; set; }
 
         public string PgPPassword { get; set; }
-    }
+
+        public CompressImagesMessage CompressImagesMessage { get; set; }
+  }
 }


### PR DESCRIPTION
AzFunction linux support is in preview so we should not use as primary
https://github.com/Azure/Azure-Functions/wiki/Azure-Functions-on-Linux-Preview

drop in the appsetting to connect the primary windows function to the linux function. 

Keeping these in separate storage accounts and if there are no problems and the feature goes GA we can switch over to using linux for primary all the time.