### PR TITLE
remove [Singleton] from compression triggers

### DIFF
--- a/CompressImagesFunction/CompressImagesFunction.cs
+++ b/CompressImagesFunction/CompressImagesFunction.cs
@@ -12,7 +12,6 @@ namespace CompressImagesFunction
 {
     public static class CompressImagesFunction
     {
-        [Singleton("{RepoName}")] // https://github.com/Azure/azure-webjobs-sdk/wiki/Singleton#scenarios
         [FunctionName("CompressImagesFunction")]
         public static async Task Trigger(
             [QueueTrigger("compressimagesmessage")]CompressImagesMessage compressImagesMessage,
@@ -36,7 +35,6 @@ namespace CompressImagesFunction
             }
         }
 
-        [Singleton("{RepoName}")]
         [FunctionName("LongCompressImagesFunction")]
         public static async Task LongTrigger(
             [QueueTrigger("longrunningcompressmessage")]CompressImagesMessage compressImagesMessage,


### PR DESCRIPTION
this was crashing the app on the new container instances


> Unhandled Exception: Microsoft.WindowsAzure.Storage.StorageException: The lease ID specified did not match the lease ID for the blob.