### PR TITLE
remove linux fallback code path

### DIFF
--- a/CompressImagesFunction/CompressImages.cs
+++ b/CompressImagesFunction/CompressImages.cs
@@ -17,7 +17,7 @@ namespace CompressImagesFunction
 {
     public static class CompressImages
     {
-        public static async Task<bool> RunAsync(CompressimagesParameters parameters, ILogger logger)
+        public static bool Run(CompressimagesParameters parameters, ILogger logger)
         {
             CredentialsHandler credentialsProvider =
                 (url, user, cred) =>
@@ -29,29 +29,7 @@ namespace CompressImagesFunction
                 CredentialsProvider = credentialsProvider,
             };
 
-            try
-            {
-                Repository.Clone(parameters.CloneUrl, parameters.LocalPath, cloneOptions);
-            }
-            catch (Exception)
-            {
-                // issue cloning, let's try to queue to the linux box to see if it can clone
-                // linux support is in preview github.com/Azure/Azure-Functions/wiki/Azure-Functions-on-Linux-Preview
-                var linuxConnectionString = Environment.GetEnvironmentVariable("linux-connectionstring");
-                if (string.IsNullOrEmpty(linuxConnectionString) == false && parameters.CompressImagesMessage != null)
-                {
-                    logger.LogInformation("bouncing to linux queue");
-                    var linuxQueue = CloudStorageAccount
-                        .Parse(linuxConnectionString)
-                        .CreateCloudQueueClient()
-                        .GetQueueReference("compressimagesmessage");
-                    await linuxQueue.CreateIfNotExistsAsync();
-                    await linuxQueue.AddMessageAsync(new CloudQueueMessage(JsonConvert.SerializeObject(parameters.CompressImagesMessage)));
-                    return false;
-                }
-
-                throw;
-            }
+            Repository.Clone(parameters.CloneUrl, parameters.LocalPath, cloneOptions);
 
             var repo = new Repository(parameters.LocalPath);
             var remote = repo.Network.Remotes["origin"];

--- a/CompressImagesFunction/CompressImagesFunction.cs
+++ b/CompressImagesFunction/CompressImagesFunction.cs
@@ -94,7 +94,7 @@ namespace CompressImagesFunction
                 CompressImagesMessage = compressImagesMessage,
             };
 
-            var didCompress = await CompressImages.RunAsync(compressImagesParameters, logger);
+            var didCompress = CompressImages.Run(compressImagesParameters, logger);
 
             if (didCompress)
             {


### PR DESCRIPTION
primary OS for ImgBot is now linux

If you can run ImgBot on linux at all then
you do not need this fallback behavior