### PR TITLE
set batchSize to 4 for CompressImagesFunction

### DIFF
--- a/CompressImagesFunction/host.json
+++ b/CompressImagesFunction/host.json
@@ -1,7 +1,12 @@
 {
   "version": "2.0",
-  "functionTimeout": "02:00:00",
+  "functionTimeout": "01:00:00",
   "logging": {
     "fileLoggingMode": "never"
-  }
+  },
+ "extensions": {
+   "queues": {
+     "batchSize": 4
+   }
+ }
 }


### PR DESCRIPTION
we were getting deadlocked doing up to 32 in parallel
this limits us to 8 in parallel since we do 2 batches at a time