### PR TITLE
bump up timeout even further

### DIFF
--- a/CompressImagesFunction/CompressImages.cs
+++ b/CompressImagesFunction/CompressImages.cs
@@ -180,7 +180,7 @@ namespace CompressImagesFunction
 
                     // returns true if the Task completed execution within the allotted time; otherwise, false.
                     // Cancel and continue with the rest
-                    if (task.Wait(60 * 1000) == false)
+                    if (task.Wait(600 * 1000) == false)
                     {
                         logger.LogInformation("Timeout processing {Image}", image);
                         tokenSource.Cancel();


### PR DESCRIPTION
- we only want to short circuit really long processes
- stay out of the way for processes that will finish eventually