### PR TITLE
keep 1 image if there is only 1 stat

### DIFF
--- a/OpenPrFunction/PullRequest.cs
+++ b/OpenPrFunction/PullRequest.cs
@@ -39,7 +39,7 @@ namespace OpenPrFunction
             {
                 RepoName = parameters.RepoName,
                 Id = result.Id,
-                NumImages = stats.Length - 1,
+                NumImages = stats.Length == 1 ? 1 : stats.Length - 1,
                 Number = result.Number,
                 SizeBefore = ImageStat.ToDouble(stats[0].Before),
                 SizeAfter = ImageStat.ToDouble(stats[0].After),


### PR DESCRIPTION
we were incorrectly reporting this case as 0 images
there is no summary row when there is a single
image in the compression summary