### PR TITLE
update commit to agree with DCO (fixes #348)

### DIFF
--- a/CompressImagesFunction/CommitMessage.cs
+++ b/CompressImagesFunction/CommitMessage.cs
@@ -47,6 +47,9 @@ namespace CompressImagesFunction
 
             commitMessage.Append(imageLog);
 
+            commitMessage.AppendLine();
+            commitMessage.AppendLine($"Signed-off-by: {KnownGitHubs.ImgBotLogin} <{KnownGitHubs.ImgBotEmail}>");
+
             return commitMessage.ToString();
         }
 

--- a/OpenPrFunction/Stats.cs
+++ b/OpenPrFunction/Stats.cs
@@ -34,6 +34,12 @@ namespace OpenPrFunction
                         continue;
                     }
 
+                    if (commitLines[i].StartsWith("Signed-off-by:"))
+                    {
+                        // skip the DCO line
+                        continue;
+                    }
+
                     var pattern = @"\*?(.*) -- (.*) -> (.*) \((.*)%\)";
                     var capture = Regex.Matches(commitLines[i], pattern)[0];
 

--- a/Test/CommitMessageTests.cs
+++ b/Test/CommitMessageTests.cs
@@ -34,7 +34,9 @@ namespace Test
                            "*Total -- 600.69kb -> 455.92kb (24.1%)" + Environment.NewLine +
                            Environment.NewLine +
                            "path/to/image2.png -- 500.32kb -> 360.13kb (28.02%)" + Environment.NewLine +
-                           "path/to/image.png -- 100.37kb -> 95.79kb (4.56%)" + Environment.NewLine;
+                           "path/to/image.png -- 100.37kb -> 95.79kb (4.56%)" + Environment.NewLine +
+                           Environment.NewLine +
+                           "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             Assert.AreEqual(expectedMessage, message);
         }
@@ -56,7 +58,9 @@ namespace Test
 
             var expectedMessage = KnownGitHubs.CommitMessageTitle + Environment.NewLine +
                              Environment.NewLine +
-                             "path/to/image.png -- 100.30kb -> 95.70kb (4.59%)" + Environment.NewLine;
+                             "path/to/image.png -- 100.30kb -> 95.70kb (4.59%)" + Environment.NewLine +
+                             Environment.NewLine +
+                             "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             Assert.AreEqual(expectedMessage, message);
         }
@@ -87,7 +91,9 @@ namespace Test
                             "*Total -- 501.89kb -> 455.68kb (9.21%)" + Environment.NewLine +
                             Environment.NewLine +
                             "path/to/image2.png -- 300.92kb -> 260.56kb (13.41%)" + Environment.NewLine +
-                            "path/to/image.png -- 200.97kb -> 195.12kb (2.91%)" + Environment.NewLine;
+                            "path/to/image.png -- 200.97kb -> 195.12kb (2.91%)" + Environment.NewLine +
+                            Environment.NewLine +
+                            "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             Assert.AreEqual(expectedMessage, message);
         }
@@ -118,7 +124,9 @@ namespace Test
                         "*Total -- 501.89kb -> 455.68kb (9.21%)" + Environment.NewLine
                         + Environment.NewLine +
                         "path/to/image2.png -- 300.92kb -> 260.56kb (13.41%)" + Environment.NewLine +
-                        "path/to/_image.png -- 200.97kb -> 195.12kb (2.91%)" + Environment.NewLine;
+                        "path/to/_image.png -- 200.97kb -> 195.12kb (2.91%)" + Environment.NewLine +
+                        Environment.NewLine +
+                        "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             Assert.AreEqual(expectedMessage, message);
         }

--- a/Test/PullRequestBodyTests.cs
+++ b/Test/PullRequestBodyTests.cs
@@ -26,7 +26,9 @@ namespace Test
                          Environment.NewLine +
                          "/featurecard.png -- 542.34kb -> 86.13kb (84.12%)" + Environment.NewLine +
                          "/graph.png -- 148.78kb -> 88.71kb (40.38%)" + Environment.NewLine +
-                         "/featured-marketplace.png -- 163.11kb -> 133.44kb (18.19%)" + Environment.NewLine;
+                         "/featured-marketplace.png -- 163.11kb -> 133.44kb (18.19%)" + Environment.NewLine +
+                         Environment.NewLine +
+                         "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
                           Environment.NewLine +
@@ -56,7 +58,9 @@ namespace Test
         {
             var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +
                          Environment.NewLine +
-                         "/featured-marketplace.png -- 163.11kb -> 160.11kb (0.02%)" + Environment.NewLine;
+                         "/featured-marketplace.png -- 163.11kb -> 160.11kb (0.02%)" + Environment.NewLine +
+                         Environment.NewLine +
+                         "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
                           Environment.NewLine +
@@ -82,7 +86,9 @@ namespace Test
         {
             var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +
                          Environment.NewLine +
-                         "/featured-marketplace.png -- 163.11kb -> 155.11kb (4.40%)" + Environment.NewLine;
+                         "/featured-marketplace.png -- 163.11kb -> 155.11kb (4.40%)" + Environment.NewLine +
+                         Environment.NewLine +
+                         "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
                           Environment.NewLine +
@@ -108,7 +114,9 @@ namespace Test
         {
             var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +
                          Environment.NewLine +
-                         "/featured-marketplace.png -- 163.11kb -> 133.44kb (18.19%)" + Environment.NewLine;
+                         "/featured-marketplace.png -- 163.11kb -> 133.44kb (18.19%)" + Environment.NewLine +
+                         Environment.NewLine +
+                         "Signed-off-by: ImgBotApp <ImgBotHelp@gmail.com>" + Environment.NewLine;
 
             var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
                           Environment.NewLine +
@@ -151,6 +159,40 @@ namespace Test
 
             var expectedMarkdown = "Beep boop. Optimizing your images is my life. https://imgbot.net/ for more information."
                 + Environment.NewLine + Environment.NewLine;
+
+            var result = PullRequestBody.Generate(Stats.ParseStats(commitMessage));
+
+            Assert.AreEqual(expectedMarkdown, result);
+        }
+
+        [TestMethod]
+        public void GivenMissingDCOCommitMessage_ShouldFormatMarkdownTable()
+        {
+            var commitMessage = "[ImgBot] Optimize images" + Environment.NewLine +
+                         Environment.NewLine +
+                         "*Total -- 854.23kb -> 308.28kb (63.91%)" + Environment.NewLine +
+                         Environment.NewLine +
+                         "/featurecard.png -- 542.34kb -> 86.13kb (84.12%)" + Environment.NewLine +
+                         "/graph.png -- 148.78kb -> 88.71kb (40.38%)" + Environment.NewLine +
+                         "/featured-marketplace.png -- 163.11kb -> 133.44kb (18.19%)" + Environment.NewLine;
+
+            var expectedMarkdown = "## Beep boop. Your images are optimized!" + Environment.NewLine +
+                          Environment.NewLine +
+                          "Your image file size has been reduced by **64%** 🎉" + Environment.NewLine +
+                          Environment.NewLine +
+                          "<details>" + Environment.NewLine +
+                          "<summary>" + Environment.NewLine +
+                          "Details" + Environment.NewLine +
+                          "</summary>" + Environment.NewLine +
+                          Environment.NewLine +
+                          "| File | Before | After | Percent reduction |" + Environment.NewLine +
+                          "|:--|:--|:--|:--|" + Environment.NewLine +
+                          "| /featurecard.png | 542.34kb | 86.13kb | 84.12% |" + Environment.NewLine +
+                          "| /graph.png | 148.78kb | 88.71kb | 40.38% |" + Environment.NewLine +
+                          "| /featured-marketplace.png | 163.11kb | 133.44kb | 18.19% |" + Environment.NewLine +
+                          "| | | | |" + Environment.NewLine +
+                          "| **Total :** | **854.23kb** | **308.28kb** | **63.91%** |" + Environment.NewLine +
+                          "</details>" + expectedFooter;
 
             var result = PullRequestBody.Generate(Stats.ParseStats(commitMessage));
 


### PR DESCRIPTION
from `git help commit`

```
-s, --signoff
           Add Signed-off-by line by the committer at the end of the commit
           log message. The meaning of a signoff depends on the project, but
           it typically certifies that committer has the rights to submit this
           work under the same license and agrees to a Developer Certificate
           of Origin (see https://developercertificate.org/ for more
           information).
```