### PR TITLE
add ICompress interface

### DIFF
--- a/CompressImagesFunction/Compressors/ICompress.cs
+++ b/CompressImagesFunction/Compressors/ICompress.cs
@@ -1,0 +1,11 @@
+namespace CompressImagesFunction.Compressors
+{
+    public interface ICompress
+    {
+        string[] SupportedExtensions { get; }
+
+        void LosslessCompress(string path);
+
+        void LossyCompress(string path);
+    }
+}

--- a/CompressImagesFunction/Compressors/ImageMagickCompress.cs
+++ b/CompressImagesFunction/Compressors/ImageMagickCompress.cs
@@ -1,0 +1,30 @@
+using ImageMagick;
+
+namespace CompressImagesFunction.Compressors
+{
+    public class ImageMagickCompress : ICompress
+    {
+        private ImageOptimizer _imageOptimizer;
+
+        public ImageMagickCompress()
+        {
+            _imageOptimizer = new ImageOptimizer
+            {
+                OptimalCompression = true,
+                IgnoreUnsupportedFormats = true,
+            };
+        }
+
+        public string[] SupportedExtensions => new[] { ".png", ".jpg", ".jpeg", ".gif" };
+
+        public void LosslessCompress(string path)
+        {
+            _imageOptimizer.LosslessCompress(path);
+        }
+
+        public void LossyCompress(string path)
+        {
+            _imageOptimizer.Compress(path);
+        }
+    }
+}

--- a/CompressImagesFunction/Compressors/SvgoCompress.cs
+++ b/CompressImagesFunction/Compressors/SvgoCompress.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics;
 using System.Linq;
 
-namespace CompressImagesFunction
+namespace CompressImagesFunction.Compressors
 {
-    public static class Svgo
+    public class SvgoCompress : ICompress
     {
-        public static string[] LosslessPlugins => new[]
+        private static string[] losslessPlugins = new[]
         {
             "cleanupAttrs",
             "cleanupListOfValues",
@@ -24,7 +25,7 @@ namespace CompressImagesFunction
             "sortAttrs",
         };
 
-        public static string[] LossyPlugins => LosslessPlugins.Concat(new[]
+        private static string[] lossyPlugins = losslessPlugins.Concat(new[]
         {
             "cleanupEnableBackground",
             "cleanupIDs",
@@ -50,5 +51,32 @@ namespace CompressImagesFunction
             "removeViewBox",
             "removeXMLNS",
         }).ToArray();
+
+        public string[] SupportedExtensions => new[] { ".svg" };
+
+        public void LosslessCompress(string path)
+        {
+            Compress(path, losslessPlugins);
+        }
+
+        public void LossyCompress(string path)
+        {
+            Compress(path, lossyPlugins);
+        }
+
+        private void Compress(string path, string[] plugins)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                FileName = "svgo",
+                Arguments = $"{path} --config=\"{{\"\"full\"\":true}}\" --multipass --enable={string.Join(",", plugins)}"
+            };
+            using (var process = Process.Start(processStartInfo))
+            {
+                process.WaitForExit(10000);
+            }
+        }
     }
 }


### PR DESCRIPTION
laying the groundwork from the discussion in #467

This doesn't change any behavior, only sets up the framework

We can open new issues with the following template to support any number of arbitrary libraries/algorithms moving forward.

new file called `SomethingCompress.cs` and implement the 3 functions

```cs
namespace CompressImagesFunction.Compressors
{
    public class SomethingCompress : ICompress
    {
        public string[] SupportedExtensions => new[] { ".XXX", ".YYY" };

        public void LosslessCompress(string path)
        {
            throw new System.NotImplementedException();
        }

        public void LossyCompress(string path)
        {
            throw new System.NotImplementedException();
        }
    }
}

```

Register the new compressor so we start picking it up at the top of [CompressImages.cs](https://github.com/dabutvin/ImgBot/blob/master/CompressImagesFunction/CompressImages.cs)

Update the [Dockerfile.CompressImages](https://github.com/dabutvin/ImgBot/blob/master/Dockerfile.CompressImages) file to properly install the library on the image
