### PR TITLE
add gifsicle compression

### DIFF
--- a/CompressImagesFunction/CompressImages.cs
+++ b/CompressImagesFunction/CompressImages.cs
@@ -23,6 +23,7 @@ namespace CompressImagesFunction
             new ImageMagickCompress(),
             new SvgoCompress(),
             new MozJpegCompress(),
+            new GifsicleCompress(),
         };
 
         public static bool Run(CompressimagesParameters parameters, ICollector<CompressImagesMessage> compressImagesMessages, ILogger logger)

--- a/CompressImagesFunction/Compressors/GifsicleCompress.cs
+++ b/CompressImagesFunction/Compressors/GifsicleCompress.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace CompressImagesFunction.Compressors
+{
+    /*
+    -O[level]
+    --optimize[=level]
+        Optimize  output GIF animations for space.  Level determines how much optimization is
+        done; higher levels take longer, but may have better  results.  There  are  currently
+        three levels:
+
+        -O1  Stores only the changed portion of each image. This is the default.
+        -O2  Also uses transparency to shrink the file further.
+        -O3  Try several optimization methods (usually slower, sometimes better results).
+
+    To modify GIF files in place, you should use the --batch option.  With  --batch,  gifsicle
+    will modify the files you specify instead of writing a new file to the standard output.
+    */
+    public class GifsicleCompress : ICompress
+    {
+        public string[] SupportedExtensions => new[] { ".gif" };
+
+        public void LosslessCompress(string path)
+        {
+            var arguments = $"-O3 --batch {path}";
+            Compress(arguments);
+        }
+
+        public void LossyCompress(string path)
+        {
+            var arguments = $"-O3 --lossy=80 --batch {path}";
+            Compress(arguments);
+        }
+
+        private void Compress(string arguments)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                FileName = "gifsicle",
+                Arguments = arguments,
+            };
+            using (var process = Process.Start(processStartInfo))
+            {
+                process.WaitForExit(10000);
+            }
+        }
+    }
+}

--- a/Dockerfile.CompressImages
+++ b/Dockerfile.CompressImages
@@ -27,5 +27,11 @@ RUN cd /tmp/mozjpeg-3.3.1/build && sh ../configure && make install
 RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran
 RUN ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
 
+# Add support for gifsicle
+RUN cd /tmp && wget https://github.com/kohler/gifsicle/archive/v1.92.tar.gz
+RUN cd /tmp && tar -xzf v1.92.tar.gz
+RUN cd /tmp/gifsicle-1.92 && autoreconf -fiv
+RUN cd /tmp/gifsicle-1.92 && sh ./configure --disable-gifview && make install
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot
 COPY --from=dotnet ["/home/site/wwwroot", "/home/site/wwwroot"]


### PR DESCRIPTION
- compile and install version 1.9.2 from https://github.com/kohler/gifsicle
- using O3 optimization level that will "Try several optimization methods (usually slower, sometimes better results)."
- lossy config set to 80
