### PR TITLE
Added basic doc section for repo administration

### DIFF
--- a/Docs/github-installation.md
+++ b/Docs/github-installation.md
@@ -1,0 +1,6 @@
+### Imgbot installation
+
+In order to manage Imgbot's intstallation, check out github's docs.
+They offer two options for managing this. 
+    - You can select which repositories you want it installed in 
+    - You can choose "all repositories including all future repositories" 

--- a/Web/src/docs/metadata.json
+++ b/Web/src/docs/metadata.json
@@ -8,6 +8,10 @@
     "title": "What is Imgbot?"
   },
   {
+    "slug": "github-installation",
+    "title": "How to install Imgbot?"
+  },
+  {
     "slug": "compression",
     "title": "Compression"
   },


### PR DESCRIPTION
Added basic doc section for repo administration, as mentioned in [this](https://github.com/dabutvin/Imgbot/issues/739) issue. 
Included doc in metadata file.