### PR TITLE
feat(docs): Add link to repo in Contributing section

### DIFF
--- a/Docs/contributing.md
+++ b/Docs/contributing.md
@@ -1,4 +1,4 @@
-All the code for Imgbot is available on GitHub. We will gladly accept contributions for the service, the website, and the documentation.
+All the code for Imgbot is [available on GitHub](https://github.com/imgbot/Imgbot). We will gladly accept contributions for the service, the website, and the documentation.
 If you are unsure what to work on, but still want to contribute you can look for an [existing issue](https://github.com/dabutvin/Imgbot/issues) in the repo.
 
 The following is where you can find out how to get set up to run locally as well as detailed information on exactly how Imgbot works.


### PR DESCRIPTION
I was looking for it while reading the docs and figured this would have been a good spot to have it.