### PR TITLE
chore: use `v3` for `actions/setup-dotnet`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,18 +6,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '6.0.402' ]
-
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1.7.2
+      - name: Setup .NET Core SDK 6.0.402
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}     
+          dotnet-version: 6.0.402 
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
Things added/changed:

- Use `v3` for `actions/setup-dotnet`.
